### PR TITLE
chore(publish): always publish as latest while jstz client is in alpha

### DIFF
--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -21,5 +21,9 @@ else
   TAG="latest"
 fi
 
+# Publish as latest
+yarn publish --access public --tag "latest"
+
 # Publish with the appropriate tag
-yarn publish --access public --tag "$TAG"
+# Tag with $TAG when jstz is out of alpha
+# yarn publish --access public --tag "$TAG"


### PR DESCRIPTION
# Context
The publish script tags the library with the pre-release tag if it has one. For the time being, our code will only be versioned with alpha. 

We want to notify package managers to pick up the latest versions instead of the user needed to specify the version they want.